### PR TITLE
fix: create extract_dir on same filesystem as out_dir

### DIFF
--- a/postgresql_archive/src/archive.rs
+++ b/postgresql_archive/src/archive.rs
@@ -349,9 +349,7 @@ pub async fn extract(bytes: &Bytes, out_dir: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let extract_dir = tempfile::tempdir()?.into_path();
-    create_dir_all(&extract_dir)?;
-
+    let extract_dir = tempfile::tempdir_in(parent_dir)?.into_path();
     debug!("Extracting archive to {}", extract_dir.to_string_lossy());
 
     for archive_entry in archive.entries()? {


### PR DESCRIPTION
`fs::rename` will fail if `extract_dir` and `out_dir` are on different filesystems. On my Fedora workstation, which mounts `/tmp` and `/home` on different filesystems, I get the following error:

```
Error: Invalid cross-device link (os error 18)
```
