### PR TITLE
don't trace self or command builders

### DIFF
--- a/postgresql_embedded/src/blocking/mod.rs
+++ b/postgresql_embedded/src/blocking/mod.rs
@@ -62,21 +62,30 @@ impl PostgreSQL {
     }
 
     /// Create a new database with the given name.
-    pub fn create_database<S: AsRef<str>>(&self, database_name: S) -> Result<()> {
+    pub fn create_database<S>(&self, database_name: S) -> Result<()>
+    where
+        S: AsRef<str> + std::fmt::Debug,
+    {
         RUNTIME
             .handle()
             .block_on(async move { self.inner.create_database(database_name).await })
     }
 
     /// Check if a database with the given name exists.
-    pub fn database_exists<S: AsRef<str>>(&self, database_name: S) -> Result<bool> {
+    pub fn database_exists<S>(&self, database_name: S) -> Result<bool>
+    where
+        S: AsRef<str> + std::fmt::Debug,
+    {
         RUNTIME
             .handle()
             .block_on(async move { self.inner.database_exists(database_name).await })
     }
 
     /// Drop a database with the given name.
-    pub fn drop_database<S: AsRef<str>>(&self, database_name: S) -> Result<()> {
+    pub fn drop_database<S>(&self, database_name: S) -> Result<()>
+    where
+        S: AsRef<str> + std::fmt::Debug,
+    {
         RUNTIME
             .handle()
             .block_on(async move { self.inner.drop_database(database_name).await })


### PR DESCRIPTION
this is a bit more personal opinion so feel free to reject on the grounds that it's not how you like it, but I preferred the traces to be more compact at the expense of gory detail, and not include passwords.

example output before with `tracing-subscriber` at debug but otherwise default:
```
2024-05-21T01:30:55.397748Z DEBUG setup{self=PostgreSQL { version: Version { major: 16, minor: Some(3), release: Some(0) }, settings: Settings { installation_dir: "<snip>\\.theseus\\postgresql\\16.3.0", password_file: "<snip>\\AppData\\Local\\Temp\\.tmpUnpHTi\\.pgpass", data_dir: "<snip>", host: "localhost", port: 0, username: "<snip>", password: "<snip>", temporary: false, timeout: Some(5s) } }}:initialize{self=PostgreSQL { version: Version { major: 16, minor: Some(3), release: Some(0) }, settings: Settings { installation_dir: "<snip>\\.theseus\\postgresql\\16.3.0", password_file: "<snip>\\AppData\\Local\\Temp\\.tmpUnpHTi\\.pgpass", data_dir: "<snip>", host: "localhost", port: 0, username: "<snip>", password: "<snip>", temporary: false, timeout: Some(5s) } }}:execute_command{self=PostgreSQL { version: Version { major: 16, minor: Some(3), release: Some(0) }, settings: Settings { installation_dir: "<snip>\\.theseus\\postgresql\\16.3.0", password_file: "<snip>\\AppData\\Local\\Temp\\.tmpUnpHTi\\.pgpass", data_dir: "<snip>", host: "localhost", port: 0, username: "<snip>", password: "<snip>", temporary: false, timeout: Some(5s) } } command_builder=InitDbBuilder { program_dir: Some("<snip>\\.theseus\\postgresql\\16.3.0\\bin"), auth: Some("password"), auth_host: None, auth_local: None, pgdata: Some("<snip>"), encoding: Some("UTF8"), allow_group_access: false, icu_locale: None, icu_rules: None, data_checksums: false, locale: None, lc_collate: None, lc_ctype: None, lc_messages: None, lc_monetary: None, lc_numeric: None, lc_time: None, no_locale: false, locale_provider: None, pwfile: Some("<snip>\\AppData\\Local\\Temp\\.tmpUnpHTi\\.pgpass"), text_search_config: None, username: Some("<snip>"), pwprompt: false, waldir: None, wal_segsize: None, set: None, debug: false, discard_caches: false, directory: None, no_clean: false, no_sync: false, no_instructions: false, show: false, sync_only: false, version: false, help: false }}: postgresql_commands::traits: Executing command: "<snip>\\.theseus\\postgresql\\16.3.0\\bin\\initdb" "--auth" "password" "--pgdata" "<snip>" "--encoding" "UTF8" "--pwfile" "<snip>\\AppData\\Local\\Temp\\.tmpUnpHTi\\.pgpass" "--username" "<snip>"
```

and after:
```
2024-05-21T01:31:16.664100Z DEBUG setup:initialize:execute_command{program="initdb"}: postgresql_commands::traits: Executing command: "C:\\Users\\rmm-m\\.theseus\\postgresql\\16.3.0\\bin\\initdb" "--auth" "password" "--pgdata" "<snip>" "--encoding" "UTF8" "--pwfile" "<snip>\\AppData\\Local\\Temp\\.tmpegLodC\\.pgpass" "--username" "<snip>"
```

this also adds the database name as an explicit field to the various database related functions, e.g.:
```
2024-05-21T01:31:20.642161Z DEBUG database_exists{database_name="<snip>"}:execute_command{program="psql"}: postgresql_commands::traits: Executing command: "<snip>\\.theseus\\postgresql\\16.3.0\\bin\\psql" "--command" "SELECT 1 FROM pg_database WHERE datname=\'<snip>\'" "--no-psqlrc" "--tuples-only" "--host" "localhost" "--port" "60078" "--username" "<snip>"
```
