### PR TITLE
fix: don't require rustls for the build script. only enable by default.

### DIFF
--- a/postgresql_embedded/Cargo.toml
+++ b/postgresql_embedded/Cargo.toml
@@ -12,7 +12,7 @@ version.workspace = true
 
 [build-dependencies]
 anyhow = { workspace = true }
-postgresql_archive = { path = "../postgresql_archive", version = "0.9.4" }
+postgresql_archive = { path = "../postgresql_archive", version = "0.9.4", default-features = false }
 tokio = { workspace = true, features = ["full"] }
 
 [dependencies]


### PR DESCRIPTION
This is a fix up to https://github.com/theseus-rs/postgresql-embedded/issues/70 … I missed that `postgresql_embedded` depends on `postgresql_archive` twice. One normal dependency. But also one `build-dependency`. The latter is missing `default-features = false`, and thus still forces the use of `rustls`.