### PR TITLE
refactor!: move version from PostgreSQL::new() to Settings

### DIFF
--- a/postgresql_embedded/src/blocking/postgresql.rs
+++ b/postgresql_embedded/src/blocking/postgresql.rs
@@ -1,6 +1,5 @@
 use crate::{Result, Settings, Status};
 use lazy_static::lazy_static;
-use postgresql_archive::Version;
 use tokio::runtime::Runtime;
 
 lazy_static! {
@@ -17,9 +16,9 @@ pub struct PostgreSQL {
 impl PostgreSQL {
     /// Create a new [`crate::postgresql::PostgreSQL`] instance
     #[must_use]
-    pub fn new(version: Version, settings: Settings) -> Self {
+    pub fn new(settings: Settings) -> Self {
         Self {
-            inner: crate::postgresql::PostgreSQL::new(version, settings),
+            inner: crate::postgresql::PostgreSQL::new(settings),
         }
     }
 
@@ -27,12 +26,6 @@ impl PostgreSQL {
     #[must_use]
     pub fn status(&self) -> Status {
         self.inner.status()
-    }
-
-    /// Get the [version](Version) of the `PostgreSQL` server
-    #[must_use]
-    pub fn version(&self) -> &Version {
-        self.inner.version()
     }
 
     /// Get the [settings](Settings) of the `PostgreSQL` server
@@ -123,13 +116,17 @@ impl PostgreSQL {
 #[cfg(test)]
 mod test {
     use super::*;
+    use postgresql_archive::Version;
 
     #[test]
     fn test_postgresql() {
-        let version = Version::new(16, Some(2), Some(0));
-        let postgresql = PostgreSQL::new(version, Settings::default());
+        let version = Version::new(16, Some(3), Some(0));
+        let settings = Settings {
+            version,
+            ..Settings::default()
+        };
+        let postgresql = PostgreSQL::new(settings);
         let initial_statuses = [Status::NotInstalled, Status::Installed, Status::Stopped];
         assert!(initial_statuses.contains(&postgresql.status()));
-        assert_eq!(postgresql.version(), &version);
     }
 }

--- a/postgresql_embedded/tests/postgresql.rs
+++ b/postgresql_embedded/tests/postgresql.rs
@@ -1,5 +1,4 @@
 use anyhow::bail;
-use postgresql_archive::LATEST;
 use postgresql_commands::psql::PsqlBuilder;
 use postgresql_commands::CommandBuilder;
 use postgresql_embedded::{PostgreSQL, Result, Settings, Status};
@@ -49,7 +48,7 @@ async fn test_temporary_database() -> Result<()> {
     assert!(settings.temporary);
 
     {
-        let mut postgresql = PostgreSQL::new(LATEST, settings);
+        let mut postgresql = PostgreSQL::new(settings);
         postgresql.setup().await?;
         postgresql.start().await?;
         assert!(data_dir.exists());
@@ -71,7 +70,7 @@ async fn test_persistent_database() -> Result<()> {
     settings.temporary = false;
 
     {
-        let mut postgresql = PostgreSQL::new(LATEST, settings);
+        let mut postgresql = PostgreSQL::new(settings);
         postgresql.setup().await?;
         postgresql.start().await?;
         assert!(data_dir.exists());
@@ -90,7 +89,6 @@ async fn test_persistent_database() -> Result<()> {
 
 #[test(tokio::test)]
 async fn test_persistent_database_reuse() -> Result<()> {
-    let version = LATEST;
     let database_name = "test";
     let mut settings = Settings::default();
     let data_dir = settings.data_dir.clone();
@@ -100,7 +98,7 @@ async fn test_persistent_database_reuse() -> Result<()> {
     settings.temporary = false;
 
     {
-        let mut postgresql = PostgreSQL::new(version, settings);
+        let mut postgresql = PostgreSQL::new(settings);
         postgresql.setup().await?;
         postgresql.start().await?;
         postgresql.create_database(database_name).await?;
@@ -121,7 +119,7 @@ async fn test_persistent_database_reuse() -> Result<()> {
     };
 
     {
-        let mut postgresql = PostgreSQL::new(version, settings);
+        let mut postgresql = PostgreSQL::new(settings);
         postgresql.setup().await?;
         postgresql.start().await?;
         assert!(postgresql.database_exists(database_name).await?);
@@ -207,7 +205,7 @@ async fn test_username_setting() -> Result<()> {
         username: "admin".to_string(),
         ..Default::default()
     };
-    let mut postgresql = PostgreSQL::new(LATEST, settings);
+    let mut postgresql = PostgreSQL::new(settings);
     postgresql.setup().await?;
     postgresql.start().await?;
 

--- a/postgresql_embedded/tests/start_config.rs
+++ b/postgresql_embedded/tests/start_config.rs
@@ -1,4 +1,3 @@
-use postgresql_archive::LATEST;
 use postgresql_commands::psql::PsqlBuilder;
 use postgresql_commands::{CommandBuilder, CommandExecutor};
 use postgresql_embedded::{PostgreSQL, Settings};
@@ -12,7 +11,7 @@ async fn start_config() -> anyhow::Result<()> {
         configuration,
         ..Default::default()
     };
-    let mut postgresql = PostgreSQL::new(LATEST, settings);
+    let mut postgresql = PostgreSQL::new(settings);
 
     postgresql.setup().await?;
     postgresql.start().await?;


### PR DESCRIPTION
This PR makes significant changes to the way the PostgreSQL `Version` is managed.  The version is moved into `Settings` to provide a consistent configuration approach.  This also enables the version to be configured from a URL. 

**API Changes**
* added `Settings.version: Version`
* changed `postgresql_embedded::PostgreSQL::new(Version,Settings)` to   `postgresql_embedded::PostgreSQL::new(Settings)`
* removed `postgresql_embedded::PostgreSQL.version()`
* removed `postgresql_embedded::PostgreSQL::default_version()`
* changed `postgresql_embedded::blocking::PostgreSQL::new(Version,Settings)` to  `postgresql_embedded::blocking::PostgreSQL::new(Settings)`
* removed `postgresql_embedded::blocking::PostgreSQL.version()`

**Migration**
If a specific version was being specified, then the code can generally change from this:
```rust
let version = V15;
let settings = Settings::default();
let postgresql = PostgreSQL::new(version, settings);
```

to this:
```rust
let version = V15;
let settings = Settings {
    version,
    ..Settings::default()
};
let postgresql = PostgreSQL::new(settings);
```
