### PR TITLE
fix: Update build dependency

### DIFF
--- a/postgresql_embedded/build/build.rs
+++ b/postgresql_embedded/build/build.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "bundled")]
 mod bundle;
 
 use anyhow::Result;


### PR DESCRIPTION
The `mod bundle` requires some additional dependencies, for example `use postgresql_archive::repository::github::repository::GitHub`. We should not require those if the `bundle` features is not needed.