### PR TITLE
Fix Custom Release URL Not Working and Compilation Failure

### DIFF
--- a/postgresql_archive/Cargo.toml
+++ b/postgresql_archive/Cargo.toml
@@ -53,8 +53,8 @@ default = [
 ]
 blocking = ["dep:tokio"]
 github = [
-    "dep:target-triple",
     "dep:serde_json",
+    "dep:target-triple",
 ]
 indicatif = [
     "dep:tracing-indicatif"

--- a/postgresql_archive/Cargo.toml
+++ b/postgresql_archive/Cargo.toml
@@ -53,6 +53,7 @@ default = [
 ]
 blocking = ["dep:tokio"]
 github = [
+    "dep:target-triple",
     "dep:serde_json",
 ]
 indicatif = [

--- a/postgresql_archive/src/configuration/custom/matcher.rs
+++ b/postgresql_archive/src/configuration/custom/matcher.rs
@@ -1,39 +1,37 @@
 use semver::Version;
 
-/// Matcher for PostgreSQL binaries from custom GitHub release repositories
-/// following the same pattern as <https://github.com/theseus-rs/postgresql-binaries>
+/// Matcher for PostgreSQL binaries from custom GitHub release repositories following the same
+/// pattern as <https://github.com/theseus-rs/postgresql-binaries>
 ///
 /// # Errors
 /// * If the asset matcher fails.
-/// TODO: support more custom settings
 pub fn matcher(_url: &str, name: &str, version: &Version) -> crate::Result<bool> {
     let target = target_triple::TARGET;
+    // TODO: consider relaxing the version format to allow for more flexibility in where the version
+    //       and target appear in the filename.
     let expected_name = format!("postgresql-{version}-{target}.tar.gz");
     Ok(name == expected_name)
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use super::*;
-    use crate::{
-        Result,
-        matcher::{self, registry::SupportsFn},
-    };
+    use crate::{Result, matcher};
+
+    const TEST_URL: &str = "https://github.com/owner/repo";
 
     #[test]
     fn test_register_custom_repo() -> Result<()> {
-        let custom_url = "https://github.com/Owner/Repo";
-        let wrapped_url = Arc::new(custom_url.to_string());
-        let supports_fn: SupportsFn = Box::new(move |url| Ok(url == wrapped_url.as_str()));
+        #[expect(clippy::unnecessary_wraps)]
+        fn supports_fn(url: &str) -> Result<bool> {
+            Ok(url == TEST_URL)
+        }
         matcher::registry::register(supports_fn, matcher)?;
 
-        let matcher = matcher::registry::get(custom_url)?;
+        let matcher = matcher::registry::get(TEST_URL)?;
         let version = Version::new(16, 3, 0);
         let expected_name = format!("postgresql-{}-{}.tar.gz", version, target_triple::TARGET);
         assert!(matcher("", &expected_name, &version)?);
-
         Ok(())
     }
 }

--- a/postgresql_archive/src/configuration/custom/matcher.rs
+++ b/postgresql_archive/src/configuration/custom/matcher.rs
@@ -1,0 +1,39 @@
+use semver::Version;
+
+/// Matcher for PostgreSQL binaries from custom GitHub release repositories
+/// following the same pattern as <https://github.com/theseus-rs/postgresql-binaries>
+///
+/// # Errors
+/// * If the asset matcher fails.
+/// TODO: support more custom settings
+pub fn matcher(_url: &str, name: &str, version: &Version) -> crate::Result<bool> {
+    let target = target_triple::TARGET;
+    let expected_name = format!("postgresql-{version}-{target}.tar.gz");
+    Ok(name == expected_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{
+        Result,
+        matcher::{self, registry::SupportsFn},
+    };
+
+    #[test]
+    fn test_register_custom_repo() -> Result<()> {
+        let custom_url = "https://github.com/Owner/Repo";
+        let wrapped_url = Arc::new(custom_url.to_string());
+        let supports_fn: SupportsFn = Box::new(move |url| Ok(url == wrapped_url.as_str()));
+        matcher::registry::register(supports_fn, matcher)?;
+
+        let matcher = matcher::registry::get(custom_url)?;
+        let version = Version::new(16, 3, 0);
+        let expected_name = format!("postgresql-{}-{}.tar.gz", version, target_triple::TARGET);
+        assert!(matcher("", &expected_name, &version)?);
+
+        Ok(())
+    }
+}

--- a/postgresql_archive/src/configuration/custom/mod.rs
+++ b/postgresql_archive/src/configuration/custom/mod.rs
@@ -1,0 +1,1 @@
+pub mod matcher;

--- a/postgresql_archive/src/configuration/custom/mod.rs
+++ b/postgresql_archive/src/configuration/custom/mod.rs
@@ -1,1 +1,3 @@
 pub mod matcher;
+
+pub use matcher::matcher;

--- a/postgresql_archive/src/configuration/mod.rs
+++ b/postgresql_archive/src/configuration/mod.rs
@@ -1,5 +1,5 @@
+pub mod custom;
 #[cfg(feature = "theseus")]
 pub mod theseus;
 #[cfg(feature = "zonky")]
 pub mod zonky;
-pub mod custom;

--- a/postgresql_archive/src/configuration/mod.rs
+++ b/postgresql_archive/src/configuration/mod.rs
@@ -2,3 +2,4 @@
 pub mod theseus;
 #[cfg(feature = "zonky")]
 pub mod zonky;
+pub mod custom;

--- a/postgresql_archive/src/error.rs
+++ b/postgresql_archive/src/error.rs
@@ -175,8 +175,8 @@ mod test {
     #[test]
     fn test_from_strip_prefix_error() {
         let path = PathBuf::from("test");
-        let stip_prefix_error = path.strip_prefix("foo").expect_err("strip prefix error");
-        let error = Error::from(stip_prefix_error);
+        let strip_prefix_error = path.strip_prefix("foo").expect_err("strip prefix error");
+        let error = Error::from(strip_prefix_error);
         assert_eq!(error.to_string(), "prefix not found");
     }
 

--- a/postgresql_archive/src/matcher/registry.rs
+++ b/postgresql_archive/src/matcher/registry.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, LazyLock, Mutex, RwLock};
 static REGISTRY: LazyLock<Arc<Mutex<MatchersRegistry>>> =
     LazyLock::new(|| Arc::new(Mutex::new(MatchersRegistry::default())));
 
-pub type SupportsFn = Box<dyn Fn(&str) -> Result<bool> + Send + Sync + 'static>;
+pub type SupportsFn = fn(&str) -> Result<bool>;
 pub type MatcherFn = fn(&str, &str, &Version) -> Result<bool>;
 
 /// Singleton struct to store matchers
@@ -66,9 +66,9 @@ impl Default for MatchersRegistry {
     fn default() -> Self {
         let mut registry = Self::new();
         #[cfg(feature = "theseus")]
-        registry.register(Box::new(|url| Ok(url == theseus::URL)), theseus::matcher);
+        registry.register(|url| Ok(url == theseus::URL), theseus::matcher);
         #[cfg(feature = "zonky")]
-        registry.register(Box::new(|url| Ok(url == zonky::URL)), zonky::matcher);
+        registry.register(|url| Ok(url == zonky::URL), zonky::matcher);
         registry
     }
 }
@@ -78,14 +78,12 @@ impl Default for MatchersRegistry {
 ///
 /// # Errors
 /// * If the registry is poisoned.
-pub fn register<F>(supports_fn: F, matcher_fn: MatcherFn) -> Result<()>
-where
-    F: Fn(&str) -> Result<bool> + Send + Sync + 'static,
-{
+pub fn register(supports_fn: SupportsFn, matcher_fn: MatcherFn) -> Result<()>
+where {
     let mut registry = REGISTRY
         .lock()
         .map_err(|error| PoisonedLock(error.to_string()))?;
-    registry.register(Box::new(supports_fn), matcher_fn);
+    registry.register(supports_fn, matcher_fn);
     Ok(())
 }
 

--- a/postgresql_archive/src/matcher/registry.rs
+++ b/postgresql_archive/src/matcher/registry.rs
@@ -78,8 +78,7 @@ impl Default for MatchersRegistry {
 ///
 /// # Errors
 /// * If the registry is poisoned.
-pub fn register(supports_fn: SupportsFn, matcher_fn: MatcherFn) -> Result<()>
-where {
+pub fn register(supports_fn: SupportsFn, matcher_fn: MatcherFn) -> Result<()> {
     let mut registry = REGISTRY
         .lock()
         .map_err(|error| PoisonedLock(error.to_string()))?;

--- a/postgresql_embedded/build/bundle.rs
+++ b/postgresql_embedded/build/bundle.rs
@@ -1,13 +1,16 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
-use postgresql_archive::VersionReq;
+use postgresql_archive::configuration::custom;
+use postgresql_archive::matcher::registry::SupportsFn;
 use postgresql_archive::repository::github::repository::GitHub;
+use postgresql_archive::{VersionReq, matcher};
 use postgresql_archive::{get_archive, repository};
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::{env, fs};
 use url::Url;
 
@@ -20,7 +23,16 @@ pub(crate) async fn stage_postgresql_archive() -> Result<()> {
     let default_releases_url = postgresql_archive::configuration::theseus::URL.to_string();
     #[cfg(not(feature = "theseus"))]
     let default_releases_url = String::new();
-    let releases_url = env::var("POSTGRESQL_RELEASES_URL").unwrap_or(default_releases_url);
+
+    let releases_url = match env::var("POSTGRESQL_RELEASES_URL") {
+        Ok(custom_url) => {
+            if !custom_url.is_empty() {
+                register_github_repository(&custom_url)?;
+            }
+            custom_url
+        }
+        Err(_) => default_releases_url,
+    };
     println!("PostgreSQL releases URL: {releases_url}");
     let postgres_version_req = env::var("POSTGRESQL_VERSION").unwrap_or("*".to_string());
     let version_req = VersionReq::from_str(postgres_version_req.as_str())?;
@@ -40,7 +52,6 @@ pub(crate) async fn stage_postgresql_archive() -> Result<()> {
         return Ok(());
     }
 
-    register_github_repository()?;
     let (asset_version, archive) = get_archive(&releases_url, &version_req).await?;
 
     fs::write(archive_version_file.clone(), asset_version.to_string())?;
@@ -52,7 +63,7 @@ pub(crate) async fn stage_postgresql_archive() -> Result<()> {
     Ok(())
 }
 
-fn register_github_repository() -> Result<()> {
+fn register_github_repository(custom_url: &str) -> Result<()> {
     repository::registry::register(
         |url| {
             let parsed_url = Url::parse(url)?;
@@ -61,5 +72,12 @@ fn register_github_repository() -> Result<()> {
         },
         Box::new(GitHub::new),
     )?;
+
+    // make custom_url as Send + Sync + 'static
+    let custom_url = Arc::new(custom_url.to_string());
+    let supports_fn: SupportsFn = Box::new(move |url| Ok(url == custom_url.as_str()));
+    // register the matcher
+    matcher::registry::register(supports_fn, custom::matcher::matcher)?;
+
     Ok(())
 }


### PR DESCRIPTION
1. Set function `postgresql_archive::configuration::theseus::matcher::matcher`  as the default matcher​
2. ​​Register the default matcher for the custom URL​