### PR TITLE
Make liblzma an optional dependency.

### DIFF
--- a/postgresql_archive/Cargo.toml
+++ b/postgresql_archive/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = { workspace = true }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 hex = { workspace = true }
-liblzma = { workspace = true }
+liblzma = { workspace = true, optional = true }
 md-5 = { workspace = true, optional = true }
 num-format = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"], optional = true }
@@ -49,7 +49,7 @@ tokio = { workspace = true }
 [features]
 default = [
     "native-tls",
-    "theseus",
+    "theseus"
 ]
 blocking = ["dep:tokio"]
 github = [
@@ -77,6 +77,7 @@ theseus = [
 ]
 zonky = [
     "maven",
+    "liblzma"
 ]
 
 [package.metadata.docs.rs]

--- a/postgresql_archive/src/extractor/mod.rs
+++ b/postgresql_archive/src/extractor/mod.rs
@@ -1,10 +1,12 @@
 mod model;
 pub mod registry;
 mod tar_gz_extractor;
+#[cfg(feature = "liblzma")]
 mod tar_xz_extractor;
 mod zip_extractor;
 
 pub use model::ExtractDirectories;
 pub use tar_gz_extractor::extract as tar_gz_extract;
+#[cfg(feature = "liblzma")]
 pub use tar_xz_extractor::extract as tar_xz_extract;
 pub use zip_extractor::extract as zip_extract;

--- a/postgresql_embedded/build/bundle.rs
+++ b/postgresql_embedded/build/bundle.rs
@@ -17,6 +17,8 @@ use url::Url;
 /// self-contained binary that does not require the PostgreSQL archive to be
 /// downloaded at runtime.
 pub(crate) async fn stage_postgresql_archive() -> Result<()> {
+    println!("cargo:rerun-if-env-changed=POSTGRESQL_VERSION");
+    println!("cargo:rerun-if-env-changed=POSTGRESQL_RELEASES_URL");
     #[cfg(feature = "theseus")]
     let default_releases_url = postgresql_archive::configuration::theseus::URL.to_string();
     #[cfg(not(feature = "theseus"))]


### PR DESCRIPTION
It is only used when extracting binaries from the zonky repo which is already behind a feature flag.

See also #187 for an xplanation of why this cause issues when a project also pulls in the xz2 crate (can't link the lzma C library twice).