### PR TITLE
Allow skipping the installation step during setup

### DIFF
--- a/postgresql_embedded/src/postgresql.rs
+++ b/postgresql_embedded/src/postgresql.rs
@@ -55,16 +55,17 @@ impl PostgreSQL {
         // conflicts with other versions.  This will also facilitate setting the status of the
         // server to the correct initial value.  If the minor and release version are not set, the
         // installation directory will be determined dynamically during the installation process.
-        if let Some(version) = postgresql.settings.version.exact_version() {
-            let path = &postgresql.settings.installation_dir;
-            let version_string = version.to_string();
+        if !postgresql.settings.trust_installation_dir {
+            if let Some(version) = postgresql.settings.version.exact_version() {
+                let path = &postgresql.settings.installation_dir;
+                let version_string = version.to_string();
 
-            if !path.ends_with(&version_string) {
-                postgresql.settings.installation_dir =
-                    postgresql.settings.installation_dir.join(version_string);
+                if !path.ends_with(&version_string) {
+                    postgresql.settings.installation_dir =
+                        postgresql.settings.installation_dir.join(version_string);
+                }
             }
         }
-
         postgresql
     }
 
@@ -93,6 +94,10 @@ impl PostgreSQL {
     /// If it doesn't, it will search all the child directories for the latest version that matches the requirement.
     /// If it returns None, we couldn't find a matching installation.
     fn installed_dir(&self) -> Option<PathBuf> {
+        if self.settings.trust_installation_dir {
+            return Some(self.settings.installation_dir.clone());
+        }
+
         let path = &self.settings.installation_dir;
         let maybe_path_version = path
             .file_name()

--- a/postgresql_embedded/src/settings.rs
+++ b/postgresql_embedded/src/settings.rs
@@ -58,6 +58,8 @@ pub struct Settings {
     pub timeout: Option<Duration>,
     /// Server configuration options
     pub configuration: HashMap<String, String>,
+    /// Skip installation and inferrence of the installation dir. Trust what the user provided.
+    pub trust_installation_dir: bool,
 }
 
 /// Settings implementation
@@ -109,6 +111,7 @@ impl Settings {
             temporary: true,
             timeout: Some(Duration::from_secs(5)),
             configuration: HashMap::new(),
+            trust_installation_dir: false,
         }
     }
 


### PR DESCRIPTION
For integration testing, postgresql_embedded is really useful, as it allows us to delegate handling of local instance setup and teardown, makes creating sample dbs simple, etc. However, we don't generally like to pull random binaries off of the internet, and would prefer to provide our own postgres installation paths. This also makes it easier for things like bazel and nix which we use in our dev/CI environemnts.

This change just allows the setup() and new() methods to trust the installation dir that the user provided, and not try to guess an installation dir based on version, or attempt to install if the path doesn't match the version. The original behavior is still the default and how most people will use this crate.