### PR TITLE
refactor: reduce map_err by adding some From<Error> implementations

### DIFF
--- a/postgresql_archive/src/configuration/zonky/extractor.rs
+++ b/postgresql_archive/src/configuration/zonky/extractor.rs
@@ -43,12 +43,10 @@ pub fn extract(bytes: &Vec<u8>, extract_directories: &ExtractDirectories) -> Res
     debug!("Extracting archive to {}", extract_dir.to_string_lossy());
 
     let reader = Cursor::new(bytes);
-    let mut archive = ZipArchive::new(reader).map_err(|error| Unexpected(error.to_string()))?;
+    let mut archive = ZipArchive::new(reader)?;
     let mut archive_bytes = Vec::new();
     for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|error| Unexpected(error.to_string()))?;
+        let mut file = archive.by_index(i)?;
         let file_name = file.name().to_string();
         if file_name.ends_with(".txz") {
             debug!("Found archive file: {file_name}");

--- a/postgresql_archive/src/error.rs
+++ b/postgresql_archive/src/error.rs
@@ -1,3 +1,5 @@
+use std::sync::PoisonError;
+
 /// PostgreSQL archive result type
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
@@ -108,6 +110,29 @@ impl From<std::path::StripPrefixError> for Error {
 impl From<url::ParseError> for Error {
     fn from(error: url::ParseError) -> Self {
         Error::ParseError(error.to_string())
+    }
+}
+
+#[cfg(feature = "maven")]
+/// Converts a [`quick_xml::DeError`] into a [`ParseError`](Error::ParseError)
+impl From<quick_xml::DeError> for Error {
+    fn from(error: quick_xml::DeError) -> Self {
+        Error::ParseError(error.to_string())
+    }
+}
+
+#[cfg(feature = "zip")]
+/// Converts a [`zip::result::ZipError`] into a [`ParseError`](Error::Unexpected)
+impl From<zip::result::ZipError> for Error {
+    fn from(error: zip::result::ZipError) -> Self {
+        Error::Unexpected(error.to_string())
+    }
+}
+
+/// Converts a [`std::sync::PoisonError<T>`] into a [`ParseError`](Error::PoisonedLock)
+impl<T> From<PoisonError<T>> for Error {
+    fn from(value: PoisonError<T>) -> Self {
+        Error::PoisonedLock(value.to_string())
     }
 }
 

--- a/postgresql_archive/src/error.rs
+++ b/postgresql_archive/src/error.rs
@@ -224,4 +224,33 @@ mod test {
         let error = Error::from(parse_error);
         assert_eq!(error.to_string(), "empty host");
     }
+
+    #[cfg(feature = "maven")]
+    #[test]
+    fn test_from_quick_xml_error() {
+        let xml = "<invalid>";
+        let quick_xml_error = quick_xml::de::from_str::<String>(xml).expect_err("quick_xml error");
+        let error = Error::from(quick_xml_error);
+        assert!(matches!(error, Error::ParseError(_)));
+    }
+
+    #[cfg(feature = "zip")]
+    #[test]
+    fn test_from_zip_error() {
+        let zip_error = zip::result::ZipError::FileNotFound;
+        let error = Error::from(zip_error);
+        assert!(matches!(error, Error::Unexpected(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("specified file not found in archive")
+        );
+    }
+
+    #[test]
+    fn test_from_poisoned_lock() {
+        let error = Error::from(std::sync::PoisonError::new(()));
+        assert!(matches!(error, Error::PoisonedLock(_)));
+        assert!(error.to_string().contains("poisoned lock"));
+    }
 }

--- a/postgresql_archive/src/extractor/zip_extractor.rs
+++ b/postgresql_archive/src/extractor/zip_extractor.rs
@@ -16,13 +16,11 @@ use zip::ZipArchive;
 pub fn extract(bytes: &Vec<u8>, extract_directories: &ExtractDirectories) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     let reader = Cursor::new(bytes);
-    let mut archive = ZipArchive::new(reader).map_err(|_| io::Error::other("Zip error"))?;
+    let mut archive = ZipArchive::new(reader)?;
     let mut extracted_bytes = 0;
 
     for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|_| io::Error::other("Zip error"))?;
+        let mut file = archive.by_index(i)?;
         let file_path = PathBuf::from(file.name());
         let file_path = PathBuf::from(file_path.file_name().unwrap_or_default());
         let file_name = file_path.to_string_lossy();

--- a/postgresql_archive/src/repository/maven/repository.rs
+++ b/postgresql_archive/src/repository/maven/repository.rs
@@ -1,4 +1,4 @@
-use crate::Error::{ArchiveHashMismatch, ParseError, RepositoryFailure, VersionNotFound};
+use crate::Error::{ArchiveHashMismatch, RepositoryFailure, VersionNotFound};
 use crate::repository::Archive;
 use crate::repository::maven::models::Metadata;
 use crate::repository::model::Repository;
@@ -60,8 +60,7 @@ impl Maven {
         let request = client.get(&url).headers(Self::headers());
         let response = request.send().await?.error_for_status()?;
         let text = response.text().await?;
-        let metadata: Metadata =
-            quick_xml::de::from_str(&text).map_err(|error| ParseError(error.to_string()))?;
+        let metadata: Metadata = quick_xml::de::from_str(&text)?;
         let artifact = metadata.artifact_id;
         let mut result = None;
         for version in &metadata.versioning.versions.version {

--- a/postgresql_extensions/src/error.rs
+++ b/postgresql_extensions/src/error.rs
@@ -1,3 +1,5 @@
+use std::sync::PoisonError;
+
 /// PostgreSQL extensions result type
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
@@ -28,4 +30,11 @@ pub enum Error {
     /// Unsupported namespace
     #[error("unsupported namespace '{0}'")]
     UnsupportedNamespace(String),
+}
+
+/// Converts a [`std::sync::PoisonError<T>`] into a [`ParseError`](Error::PoisonedLock)
+impl<T> From<PoisonError<T>> for Error {
+    fn from(value: PoisonError<T>) -> Self {
+        Error::PoisonedLock(value.to_string())
+    }
 }

--- a/postgresql_extensions/src/error.rs
+++ b/postgresql_extensions/src/error.rs
@@ -38,3 +38,15 @@ impl<T> From<PoisonError<T>> for Error {
         Error::PoisonedLock(value.to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_poison_error() {
+        let error = Error::from(std::sync::PoisonError::new(()));
+        assert!(matches!(error, Error::PoisonedLock(_)));
+        assert!(error.to_string().contains("poisoned lock"));
+    }
+}


### PR DESCRIPTION
cuts down on use of map_err by adding From impls for common errors